### PR TITLE
create AF_UNIX sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Role Variables
 | fluentd\_certs\_dir           | directory where cert files locate | "{{ \_\_fluentd\_certs\_dir }}" |
 | fluentd\_ca\_key              | content of ca\_key.pem | "" |
 | fluentd\_ca\_cert             | content of ca\_cert.pem | "" |
-| fluentd\_buffer\_path         |`path to file-based buffer directory | /var/spool/fluentd |
+| fluentd\_buffer\_path         | path to file-based buffer directory | /var/spool/fluentd |
+| fluentd\_unix\_pipe\_dir      | path to directory where AF\_UNIX pipe should be created | {{ \_\_fluentd\_unix\_pipe\_dir }} |
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,4 @@ fluentd_configs: {}
 fluentd_ca_key:
 fluentd_ca_cert:
 fluentd_buffer_path: /var/spool/fluentd
+fluentd_unix_pipe_dir: "{{ __fluentd_unix_pipe_dir }}"

--- a/spec/serverspec/default_spec.rb
+++ b/spec/serverspec/default_spec.rb
@@ -10,6 +10,7 @@ fluentd_work_dir     = '/var/spool/fluentd'
 fluentd_gem_bin      = '/usr/bin/fluent-gem'
 fluentd_certs_dir    = '/etc/fluentd/certs'
 fluentd_buffer_dir   = '/var/spool/fluentd'
+fluentd_unix_pipe_dir= '/var/tmp/fluentd'
 
 case os[:family]
 when 'freebsd'
@@ -75,4 +76,18 @@ describe file(fluentd_buffer_dir) do
   it { should be_owned_by fluentd_user_name }
   it { should be_grouped_into fluentd_user_group }
   it { should be_mode 755 }
+end
+
+describe file(fluentd_unix_pipe_dir) do
+  it { should be_directory }
+  it { should be_owned_by fluentd_user_name }
+  it { should be_grouped_into fluentd_user_group }
+  it { should be_mode 755 }
+end
+
+describe file("#{fluentd_unix_pipe_dir}/fluentd.sock") do
+  it { should be_pipe }
+  it { should be_owned_by fluentd_user_name }
+  it { should be_grouped_into fluentd_user_group }
+  it { should be_mode 660 }
 end

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,24 @@
     owner: "{{ fluentd_user }}"
     group: "{{ fluentd_group }}"
 
+- name: Ensure unix pipe directory exists
+  file:
+    path: "{{ fluentd_unix_pipe_dir }}"
+    state: directory
+    mode: 0755
+    owner: "{{ fluentd_user }}"
+    group: "{{ fluentd_group }}"
+
+- command: "mkfifo -m 660 {{ fluentd_unix_pipe_dir }}/fluentd.sock"
+  args:
+    creates: "{{ fluentd_unix_pipe_dir }}/fluentd.sock"
+
+- name: Ensure pipe permission is 660
+  file:
+    path: "{{ fluentd_unix_pipe_dir }}/fluentd.sock"
+    owner: "{{ fluentd_user }}"
+    group: "{{ fluentd_group }}"
+
 - name: Ensure certs_dir exists
   file:
     path: "{{ fluentd_certs_dir }}"

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -4,3 +4,4 @@ __fluentd_config_dir: "/usr/local/etc/fluentd/conf.d"
 __fluentd_config_path: "/usr/local/etc/fluentd/fluent.conf"
 __fluentd_gem_bin: "/usr/local/bin/fluent-gem"
 __fluentd_certs_dir: "/usr/local/etc/fluentd/certs"
+__fluentd_unix_pipe_dir: /var/tmp/fluentd


### PR DESCRIPTION
when the tranport is secure_forward, local clients cannot post events
unless they manage to support the protocol, which is NOT plain TLS.
