### PR TITLE
[bugfix] fix conditionals to test emptiness

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -38,9 +38,9 @@ platforms:
       box: trombik/ansible-ubuntu-14.04-amd64
       box_check_update: false
 
-  - name: centos-7.2-x86_64
+  - name: centos-7.3-x86_64
     driver:
-      box: trombik/ansible-centos-7.2-x86_64
+      box: trombik/ansible-centos-7.3-x86_64
       box_check_update: false
 
 suites:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ script:
   # See if the repo is private
   - if curl --silent --output /dev/null --dump-header - "https://github.com/${TRAVIS_REPO_SLUG}" | grep "Status:[[:space:]]*404"; then touch .private_repo; fi
 
+  # Download depended roles
+  - if [ -f requirements.yml ]; then ansible-galaxy install -r requirements.yml -p extra_roles; fi
+
   # Basic role syntax check
   #
   # If it is a private repo, it _usually_ has secret information, or encrypted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,13 +52,17 @@
     owner: "{{ fluentd_user }}"
     group: "{{ fluentd_group }}"
     validate: openssl x509 -noout -in %s
-  when: fluentd_ca_cert
+  when:
+    - fluentd_ca_cert is defined
+    - fluentd_ca_cert != ''
 
 - assert:
     msg: "When `fluentd_ca_key` is used, you need to set `fluentd_ca_private_key_passphrase`"
     that:
       - fluentd_ca_private_key_passphrase != ""
-  when: fluentd_ca_key
+  when:
+    - fluentd_ca_key is defined
+    - fluentd_ca_key != ''
 
 - name: Install ca_key.pem
   template:
@@ -70,7 +74,9 @@
     validate: openssl rsa -check -noout -passin env:FLUENTD_CA_PASS -in %s
   environment:
     FLUENTD_CA_PASS: "{{ fluentd_ca_private_key_passphrase }}"
-  when: fluentd_ca_key
+  when:
+    - fluentd_ca_key is defined
+    - fluentd_ca_key != ''
 
 #- include: configure-leaf.yml
 


### PR DESCRIPTION
when you test a variable, and its value is a string, recent `ansible`
throws a cryptic error.

```
The conditional check 'test' failed. The error was: expected token 'end
of statement block', got '...'
```

where '...' is the string.

here is what the dev says:
ansible/ansible#20392 (comment)

> that actually happens on older versions of Ansible as well, so that
> case is not a regression, it's just a side-effect of the fact that we
> allow bare variables like this in conditionals. The correct solution is
> to use is `defined` in these kinds of situations where the variable may
> not contain a boolean value.

in short, when the variable is `true` or `false`, it works as expected.

```yaml

- name: foo
  ...
  when: true_or_false
```

but when the variable is not boolean, use `defined` and `!=''` to test
emptiness.